### PR TITLE
fixed ordering for ScoreMatrixBin to order by original rank in windows

### DIFF
--- a/R/scoreMatrixBin.R
+++ b/R/scoreMatrixBin.R
@@ -90,6 +90,8 @@ summarizeViewsRle = function(my.vList, windows, bin.op, bin.num, strand.aware){
 		orig.rows=which(as.character(strand(windows))== '-')
         mat[rownames(mat) %in% orig.rows,] = mat[rownames(mat) %in% orig.rows, ncol(mat):1]
 	}
+
+	mat = mat[order(as.numeric(rownames(mat))),]
 	return(mat)
 	
 }


### PR DESCRIPTION
The output of ScoreMatrixBin was ordered by chromosome and _then_ by the original rank, unlike ScoreMatrix which is ordered by original rank. I added a line to reorder the output matrix.
