### PR TITLE
fix some bugs affecting bioc-devel versions

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: genomation
 Type: Package
 Title: : R package for annotation and visualization of genomic data
-Version: 0.99.0.2
-Date: 2011-11-30
+Version: 0.99.0.3
+Date: 2014-08-22
 Author: Altuna Akalin, Vedran Franke
 Maintainer: Altuna Akalin <aakalin@gmail.com>, Vedran Franke <vedran.franke@gmail.com>
 Description: A package for genomic feature analysis and annotation users can visualize and quantify genomic features over pre-defined regions such as promoters, exons, introns. The genomic features are any feature with a definite chromosome position and may be associated with a score, such as aligned reads from HT-seq experiments, TF binding sites, methylation scores, etc. The package can use GRanges objects, BAM files and BigWig files. It can read BED and GFF files. On top of that, it can read any tabular genomic feature data as long as it has minimal information on locations of genomic features.
@@ -11,7 +11,7 @@ LazyLoad: yes
 VignetteBuilder: knitr
 biocViews: Annotation, HighThroughputSequencing, Visualization
 Depends:
-    R (>= 3.0.0),grid
+    R (>= 3.0.0),grid,GenomicRanges,GenomicAlignments
 Imports:
   GenomicRanges,
   IRanges,

--- a/NAMESPACE
+++ b/NAMESPACE
@@ -1,10 +1,12 @@
 import(methods)
 import(GenomicRanges)
+import(GenomicAlignments)
 import(IRanges)
 import(Rsamtools)
 import(ggplot2)
 importMethodsFrom("rtracklayer", import)
-#importMethodsFrom("GenomicRanges",elementMetadata,countOverlaps,findOverlaps, seqnames, seqlengths, strand,"strand<-")
+#importMethodsFrom("GenomicRanges",elementMetadata,countOverlaps,findOverlaps, seqnames, seqlengths, strand,"strand<-",GRanges)
+importMethodsFrom("GenomicAlignments",readGAlignmentsFromBam)
 
 #importClassesFrom("GenomicRanges",GRanges,GRangesList)
 


### PR DESCRIPTION
the examples now run properly on a devel install

R> packageVersion('genomation')
[1] '0.99.0.3'

R> biocVersion()
[1] '3.0'

R> sessionInfo()
R version 3.1.0 (2014-04-10)
Platform: x86_64-pc-linux-gnu (64-bit)

locale:
 [1] LC_CTYPE=en_US.UTF-8       LC_NUMERIC=C  
 [3] LC_TIME=en_US.UTF-8        LC_COLLATE=en_US.UTF-8  
 [5] LC_MONETARY=en_US.UTF-8    LC_MESSAGES=en_US.UTF-8  
 [7] LC_PAPER=en_US.UTF-8       LC_NAME=C  
 [9] LC_ADDRESS=C               LC_TELEPHONE=C  
[11] LC_MEASUREMENT=en_US.UTF-8 LC_IDENTIFICATION=C       

attached base packages:
[1] parallel  grid      stats     graphics  grDevices datasets  utils  
[8] methods   base     

other attached packages:
 [1] genomation_0.99.0.3      GenomicAlignments_1.1.25 Rsamtools_1.17.33  
 [4] Biostrings_2.33.13       XVector_0.5.7            GenomicRanges_1.17.35  
 [7] GenomeInfoDb_1.1.18      IRanges_1.99.24          S4Vectors_0.1.2  
[10] BiocGenerics_0.11.4      BiocInstaller_1.15.5     bigrquery_0.1  
[13] gtools_3.4.1             dplyr_0.2               

loaded via a namespace (and not attached):
 [1] assertthat_0.1       BatchJobs_1.3        BBmisc_1.7  
 [4] BiocParallel_0.99.13 bitops_1.0-6         brew_1.0-6  
 [7] checkmate_1.3        codetools_0.2-9      colorspace_1.2-4  
[10] data.table_1.9.2     DBI_0.2-7            digest_0.6.4  
[13] fail_1.2             foreach_1.4.2        ggplot2_1.0.0  
[16] gridBase_0.4-7       gtable_0.1.2         httr_0.4  
[19] impute_1.39.0        iterators_1.0.7      jsonlite_0.9.10  
[22] MASS_7.3-34          munsell_0.4.2        plyr_1.8.1  
[25] proto_0.3-10         Rcpp_0.11.2          RCurl_1.95-4.3  
[28] reshape2_1.4         RSQLite_0.11.4       rtracklayer_1.25.13 
[31] scales_0.2.4         sendmailR_1.1-2      stats4_3.1.0  
[34] stringr_0.6.2        tools_3.1.0          XML_3.98-1.1  
[37] zlibbioc_1.11.1     
