### PR TITLE
Load GenomicRanges

### DIFF
--- a/vignettes/GenomationManual-knitr.Rmd
+++ b/vignettes/GenomationManual-knitr.Rmd
@@ -270,7 +270,8 @@ The *heatMatrix* function can also take a list of numeric vectors
 designating row names, or a factor variable that represent our 
 annotation over the windows.
 ```{r heatMatrix2, eval=FALSE, tidy=TRUE, fig.width=4, fig.height=3}
-  data(cage)
+library(GenomicRanges)   # provides function "countOverlaps"
+data(cage)
 data(promoters)
 data(cpgi)
 


### PR DESCRIPTION
The function "countOverlaps" from "GenomicRanges" allows t 

The code starting at line 273 (i.e. demonstrating *heatMatrix*) needs the function "countOverlaps". Loading the library "GenomicRanges" provides this function and allows this code to run in a naive R session (assuming that the library "genomation" has been loaded already).