### PR TITLE
plotMeta bug when dispersion=NULL & smoothfun!=NULL

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: genomation
 Type: Package
 Title: Summary, annotation and visualization of genomic data
-Version: 1.1.14
+Version: 1.1.15
 Author: Altuna Akalin [aut, cre], Vedran Franke [aut, cre], Katarzyna Wreczycka [aut], Liz Ing-Simmons [ctb]	
 Maintainer: Altuna Akalin <aakalin@gmail.com>, Vedran Franke <vedran.franke@gmail.com>
 Description: A package for summary and annotation of genomic intervals. Users can visualize and 

--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,10 @@
+genomation 1.1.15
+--------------
+
+IMPROVEMENTS AND BUG FIXES
+
+* fix bug of plotMeta() when dispersion=NULL and smoothfun is not NULL
+
 genomation 1.1.14
 --------------
 

--- a/R/plotMatrix.R
+++ b/R/plotMatrix.R
@@ -393,7 +393,7 @@ plotMeta<-function(mat, centralTend="mean",
     if(winsorize[2]<100 | winsorize[1]>0){
       mat[[i]]=.winsorize(mat[[i]],winsorize)
     }
-  
+    
     # get meta profiles by taking the mean/median
     if(centralTend=="mean"){
       if(!is.null(dispersion) && dispersion=="IQR"){
@@ -434,7 +434,7 @@ plotMeta<-function(mat, centralTend="mean",
     if(meta.rescale){
       val2unit <- function(x){(x-min(x, na.rm = TRUE))/(max(x, na.rm = TRUE)-min(x, na.rm = TRUE))} 
       metas[[i]]=val2unit(metas[[i]])
-      if(dispersion %in% disp.args){
+      if(!is.null(dispersion) && dispersion %in% disp.args){
         bound2[[i]]=val2unit(bound2[[i]])
         if(dispersion=="IQR"){
           q1[[i]]=val2unit(q1[[i]])
@@ -448,7 +448,7 @@ plotMeta<-function(mat, centralTend="mean",
     #smoothing
     if(!is.null(smoothfun)){
       metas[[i]] <- smoothfun(metas[[i]])$y
-      if(dispersion %in% disp.args){
+      if(!is.null(dispersion) && dispersion %in% disp.args){
         bound2[[i]] <- smoothfun(bound2[[i]])$y
         if(dispersion=="IQR"){
           q1[[i]] <- smoothfun(q1[[i]])$y


### PR DESCRIPTION
plotMeta:
        added !is.null(dispersion) to if closures where I check if dispersion argument is in allowed namespace ("sd","se" or "IQR")