### PR TITLE
reading paired-end issue in readBam()

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: genomation
 Type: Package
 Title: Summary, annotation and visualization of genomic data
-Version: 1.1.15
+Version: 1.1.16
 Author: Altuna Akalin [aut, cre], Vedran Franke [aut, cre], Katarzyna Wreczycka [aut], Liz Ing-Simmons [ctb]	
 Maintainer: Altuna Akalin <aakalin@gmail.com>, Vedran Franke <vedran.franke@gmail.com>
 Description: A package for summary and annotation of genomic intervals. Users can visualize and 

--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,14 @@
+genomation 1.1.16
+--------------
+
+IMPROVEMENTS AND BUG FIXES
+
+* issue with readBam() used in scoreMatrix() to read bam files.
+  Reading paired-end reads was extremely slow, because of lines of code
+  that were responsible for checking if both mates from pair are not counted twice,
+  e.g. when mates map into two different windows of interest. Right now we allow it.
+  Fixed bug in reading single-end reads.
+
 genomation 1.1.15
 --------------
 

--- a/R/scoreMatrix.R
+++ b/R/scoreMatrix.R
@@ -79,8 +79,6 @@ readBam = function(target, windows, rpm=FALSE,
   # check the ScanBamParam object
   if(!is.null(param) & class(param)!='ScanBamParam')
     stop('param needs to be an object of class ScanBamParam')
-
-  wind = .windows.range(windows)
   
   if(paired.end){
     
@@ -88,41 +86,22 @@ readBam = function(target, windows, rpm=FALSE,
                         isUnmappedQuery=FALSE, hasUnmappedMate=FALSE)
     #reads that map into window which stretches from start of the first windows to end of the last window
     if(is.null(param)){
-      param <- ScanBamParam(which=reduce(wind, ignore.strand=TRUE), flag=flag)
+      param <- ScanBamParam(which=reduce(windows, ignore.strand=TRUE), flag=flag)
     }else{
       bamWhich(param) <- reduce(windows, ignore.strand=TRUE)
     }
     alnp <- readGAlignmentPairs(target, param=param, use.names=TRUE)
     
-    #reads within gaps between windows
-    gaps.wind <- gaps(windows)
-    if(is.null(param)){
-      param <- ScanBamParam(which=reduce(gaps.wind, ignore.strand=TRUE), flag=flag)
-    }else{
-      bamWhich(param) <- reduce(gaps.wind, ignore.strand=TRUE)
-    }
-    alnp.gap <- readGAlignmentPairs(target, param=param, use.names=TRUE)
-    alnp.gap.uniq <- unique(granges(alnp.gap))
-    reads.within.gaps <- alnp.gap.uniq[as.data.frame(findOverlaps(alnp.gap.uniq, gaps.wind, type="within"))$queryHits]
-    
-    #reads that overlap with windows (at least one read from pair)
-    if(length(reads.within.gaps)!=0){
-      g <- findOverlaps(alnp, reads.within.gaps, type="equal")
-      alns <- alnp[-unique(as.data.frame(g)$queryHits)]
-    }else{
-      alns <- alnp
-    }
-    
     if(stranded){
-      # if first read is on - (resp. +) strand then return - (+)
-      strand(alns) = ifelse(start(first(alns)) < start(last(alns)), "+", "-") 
+      # if first read is on - (resp. +) strand then return - (+) 
+      strand(alnp) = ifelse(start(first(alnp)) < start(last(alnp)), "+", "-") 
     }
-    alns <- granges(alns)
+    alns <- granges(alnp)
     
   }else{
     
     if(is.null(param)){
-      param <- ScanBamParam(which=reduce(wind, ignore.strand=TRUE))
+      param <- ScanBamParam(which=reduce(windows, ignore.strand=TRUE))
     }else{
       bamWhich(param) <- reduce(windows, ignore.strand=TRUE)
     }

--- a/inst/unitTests/test_ScoreMatrix.R
+++ b/inst/unitTests/test_ScoreMatrix.R
@@ -96,11 +96,12 @@ test_ScoreMatrix_character_GRanges = function()
   windows = GRanges(rep(c(1,2),each=2), IRanges(rep(c(1,2), times=2), width=5), 
                     strand=c('-','+','-','+'))
   
-  target.paired.end = GRanges(rep(1,each=7), 
-                              IRanges(c(1,1,2,3,7,8,9), width=c(19, 19, 19, 19, 16, 16, 16)),
-                              strand=rep("+", times=7))
+  target.paired.end = GRanges(rep(1,each=12), 
+                              IRanges(start=c(1,1,2,2,3,3,7,7,8,8,9,9), end=c(19, 19, 20, 20, 21, 21,22,22,23,23,24,24)),
+                              strand=rep("+", times=12))
   windows.paired.end = GRanges(rep(c(1),each=4), IRanges(c(7,8,20, 21), width=10), 
                                strand=c('+','+','+','+'))
+    
 
   # -----------------------------------------------#
   # usage
@@ -126,10 +127,10 @@ test_ScoreMatrix_character_GRanges = function()
   m4 = ScoreMatrix(resize(unique(target), width=1), windows)
   checkEquals(s4,m4)
   
-  # bam file with paired-end reads, rpm=FALSE, unique=TRUE, extend=16
+  # bam file with paired-end reads
   bam.pe.file = system.file('unitTests/test_pairedend.bam', package='genomation')
-  s5 = ScoreMatrix(bam.pe.file, windows.paired.end, type='bam', bam.paired.end=TRUE, unique=TRUE, extend=16)
-  m5 = ScoreMatrix(resize(unique(target.paired.end), width=16), windows.paired.end)
+  s5 = ScoreMatrix(bam.pe.file, windows.paired.end, type='bam', bam.paired.end=TRUE)
+  m5 = ScoreMatrix(target.paired.end, windows.paired.end, bam.paired.end=TRUE)
   checkEquals(s5,m5)
 
   # -----------------------------------------------#


### PR DESCRIPTION
ScoreMatrix:
 - removed code that was slowing down reading paired-end alignment. Right now when mates from pair map into two different windows of interest then they are duplicated (counted twice).
 - fixed bug in readBam() in reading single-end reads