### PR TITLE
fixed a bug in multiHeatMatrix after introducing Ops

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: genomation
 Type: Package
 Title: Summary, annotation and visualization of genomic data
-Version: 1.1.23
+Version: 1.1.24
 Author: Altuna Akalin [aut, cre], Vedran Franke [aut, cre], Katarzyna Wreczycka [aut], Liz Ing-Simmons [ctb]	
 Maintainer: Altuna Akalin <aakalin@gmail.com>, Vedran Franke <vedran.franke@gmail.com>
 Description: A package for summary and annotation of genomic intervals. Users can visualize and 

--- a/NEWS
+++ b/NEWS
@@ -1,7 +1,14 @@
+genomation 1.1.24
+--------------
+
+IMPROVEMENTS AND BUG FIXES
+
+*  Fixed a bug in multiHeatMatrix that occured after version 1.1.19
+   
 genomation 1.1.23
 --------------
 
-NEW FUNCTIONS AND FEATURES
+IMPROVEMENTS AND BUG FIXES
 
 *  Fixed a bug in plotMeta that occured after version 1.1.19
    

--- a/R/plotMatrix.R
+++ b/R/plotMatrix.R
@@ -1165,8 +1165,7 @@ heatMatrix<-function(mat,grid=FALSE,col=NULL,xcoords=NULL,
 #' sml=new("ScoreMatrixList",list(a=scores1,b=scores2))
 #'
 #' # use with k-means
-#' \donttest{
-#' multiHeatMatrix(sml,
+#' \donttest{multiHeatMatrix(sml,
 #'                  clustfun=function(x) kmeans(x, centers=2)$cluster,
 #'                  cex.axis=0.8,xcoords=c(-1000,1000),
 #'                  winsorize=c(0,99),
@@ -1283,7 +1282,7 @@ multiHeatMatrix<-function(sml,grid=TRUE,col=NULL,xcoords=NULL,
   # alternative is to take log or sth
   # but that should be done prior to heatMatrix
   if(winsorize[2]<100 | winsorize[1]>0){
-    mat.list=lapply(mat.list,function(x) .winsorize(x,winsorize) )
+    mat.list=lapply(mat.list,function(x) .winsorize(x@.Data, winsorize) )
   }
   
   

--- a/man/multiHeatMatrix.Rd
+++ b/man/multiHeatMatrix.Rd
@@ -147,8 +147,7 @@ scores2=ScoreMatrix(target=cpgi,windows=promoters,strand.aware=TRUE)
 sml=new("ScoreMatrixList",list(a=scores1,b=scores2))
 
 # use with k-means
-\donttest{
-multiHeatMatrix(sml,
+\donttest{multiHeatMatrix(sml,
                  clustfun=function(x) kmeans(x, centers=2)$cluster,
                  cex.axis=0.8,xcoords=c(-1000,1000),
                  winsorize=c(0,99),


### PR DESCRIPTION
multiHeatMatrix:
     - use @.Data to get matrix out of ScoreMatrix

I checked code in /donttest{} closure manually for similar bugs and I don't find more of them.