### PR TITLE
update to v.1.3.2, fixed negative values for metadata, changed error msg in ScoreMatrix(Bin)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: genomation
 Type: Package
 Title: Summary, annotation and visualization of genomic data
-Version: 1.3.1
+Version: 1.3.2
 Author: Altuna Akalin [aut, cre], Vedran Franke [aut, cre], Katarzyna Wreczycka [aut], Liz Ing-Simmons [ctb]	
 Maintainer: Altuna Akalin <aakalin@gmail.com>, Vedran Franke <vedran.franke@gmail.com>
 Description: A package for summary and annotation of genomic intervals. Users can visualize and 

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: genomation
 Type: Package
 Title: Summary, annotation and visualization of genomic data
-Version: 1.3.2
+Version: 1.3.3
 Author: Altuna Akalin [aut, cre], Vedran Franke [aut, cre], Katarzyna Wreczycka [aut], Liz Ing-Simmons [ctb]	
 Maintainer: Altuna Akalin <aakalin@gmail.com>, Vedran Franke <vedran.franke@gmail.com>
 Description: A package for summary and annotation of genomic intervals. Users can visualize and 

--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,11 @@
+genomation 1.3.3
+--------------
+
+IMPROVEMENTS AND BUG FIXES
+
+*  fixed reading genomic files with numeric metadata columns
+   (readTableFast converted their numeric values to positive integers)
+  
 genomation 1.3.2
 --------------
 

--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,17 @@
+genomation 1.3.2
+--------------
+
+IMPROVEMENTS AND BUG FIXES
+
+*  strands of reads in paired-end BAM files are inferred depending on strand of 
+   first alignment from the pair. It's a default setting of the strandMode argument
+   in the readGAlignmentPairs function.
+*  added new argument to ScoreMatrix, ScoreMatrixBin and ScoreMatrixList functions
+   library.size indicating total number of aligned reads of a BAM file for
+   normalization.
+* removed argument stranded from ScoreMatrix, ScoreMatrixBin and 
+  ScoreMatrixList functions
+
 genomation 1.3.1
 --------------
 

--- a/R/readData.R
+++ b/R/readData.R
@@ -51,7 +51,7 @@ readTableFast<-function(filename,header=TRUE,skip=0,sep="\t"){
   }else if(skip=="auto"){
     skip = detectUCSCheader(filename)
   }
-  
+ 
   if(grepl("^.*(.zip)[[:space:]]*$", filename)){
 	tab30rows <- read.zip(filename,
 			      sep=sep, 
@@ -68,15 +68,25 @@ readTableFast<-function(filename,header=TRUE,skip=0,sep="\t"){
 				stringsAsFactors=FALSE)
   }
   classes  <- sapply(tab30rows, class)
-  cl <- paste(sapply(classes, function(x) substr(x, 0, 1)), collapse="")
-  
+  cl=""
+  for(cla in classes){
+    if(cla=="character"){
+      cl=paste0(cl, "c")
+    }else if(cla=="numeric" | cla=="double"){
+      cl=paste0(cl, "d")
+    }else if(cla=="integer"){
+      cl=paste0(cl, "i")
+    }else if(cla=="logical")
+      cl=paste0(cl, "l")
+  }
   
   df <- read_delim(file=filename, 
                    delim=sep, 
                    skip=skip,
                    col_names=header,
                    col_types=cl,
-                   locale=locale(decimal_mark = ",", grouping_mark = "_"))
+                   locale=locale(grouping_mark = "_")
+                   )
   #changing default variables names from read_delim (X[0-9]+) to data.frame (V[0-9]+)
   colnames(df) <- gsub("^X(\\d+)$", "V\\1", colnames(df)) 
   return(as.data.frame(df))

--- a/R/scoreMatrix.R
+++ b/R/scoreMatrix.R
@@ -363,9 +363,13 @@ setMethod("ScoreMatrix",signature("character","GRanges"),
             }
             
             fm = c('bam','bigWig')
-            if(!type %in% fm)
-              stop(paste(c('currently supported formats are', paste(fm, collapse=", "))))
-            
+            if(!type %in% fm){
+	      if(type==""){
+		stop(paste0('set argument type to "bam" or "BigWig"\n'))
+	      }
+	      stop('currently supported formats are bam and BigWig\n')
+            }
+              
             if(type == 'bam' & !grepl('bam$',target))
               warning('you have set type="bam", but the designated file does not have .bam extension')
             if(type == 'bigWig' & !grepl('bw$|bigWig$|bigwig$',target))

--- a/R/scoreMatrix.R
+++ b/R/scoreMatrix.R
@@ -63,8 +63,9 @@ galpTo2Ranges <- function(x)
 # given a big bam path reads the big wig file into a RleList
 # to be used by ScoreMatrix:char,GRanges
 readBam = function(target, windows, rpm=FALSE,
-                   unique=FALSE, extend=0, param=NULL, paired.end=FALSE, stranded=TRUE, ...){
-  
+                   unique=FALSE, extend=0, param=NULL, 
+                   paired.end=FALSE, library.size=NULL, ...){
+
   # check the ScanBamParam object
   if(!is.null(param) & class(param)!='ScanBamParam')
     stop('param needs to be an object of class ScanBamParam')
@@ -84,11 +85,6 @@ readBam = function(target, windows, rpm=FALSE,
     
     # remove rows that are duplicated when mates of pair map into two different windows
     alnp = alnp[!duplicated(names(alnp))]
-    
-    if(stranded){
-      # if first read is on - (resp. +) strand then return - (+) 
-      strand(alnp) = ifelse(start(first(alnp)) < start(last(alnp)), "+", "-") 
-    }
     alns <- granges(alnp)
     
   }else{
@@ -100,9 +96,6 @@ readBam = function(target, windows, rpm=FALSE,
     }
     alns <- granges(readGAlignments(target, param=param, use.names=TRUE))
   }
-  
-  if(!stranded)
-    strand(alns) = "*"
   
   if(unique)
     alns = unique(alns)
@@ -117,7 +110,11 @@ readBam = function(target, windows, rpm=FALSE,
   
   if(rpm){
     message('Normalizing to rpm ...')
-    total = 1e6/sum(countBam(BamFile(target))$records)
+    if(is.null(library.size)){
+      total = 1e6/sum(countBam(BamFile(target))$records)
+    }else{
+      total = 1e6/library.size
+    }
     covs = covs * total
   }
   
@@ -191,7 +188,7 @@ readBigWig = function(target, windows=NULL, ...){
 #' @param type if target is a character vector of file paths, then type designates
 #'              the type of the corresponding files (bam or bigWig)
 #' @param rpm boolean telling whether to normalize the coverage to per milion 
-#'                    reads. FALSE by default.
+#'                    reads. FALSE by default. See \code{library.size}.
 #' @param unique boolean which tells the function to remove duplicated reads 
 #'              based on chr, start, end and strand
 #' @param extend numeric which tells the function to extend the reads to width=extend
@@ -199,14 +196,24 @@ readBigWig = function(target, windows=NULL, ...){
 #' @param bam.paired.end boolean indicating whether given BAM file contains 
 #'                       paired-end reads (default:FALSE).
 #'                       Paired-reads will be treated as fragments.
-#' @param stranded boolean which tells whether given BAM file is from a strand-specific
-#'                 protocol (default:TRUE). If FALSE then strands of reads 
-#'                 will be set up to "*".
+#' @param library.size numeric indicating total number of mapped reads in a BAM file
+#'                            (\code{rpm} has to be set to TRUE).
+#'                            If is not given (default: NULL) then library size 
+#'                            is calculated using the Rsamtools package functions:
+#'                            sum(countBam(BamFile(\code{target}))$records).
+#' 
 #' @note
 #' We assume that a paired-end BAM file contains reads with unique ids and we remove 
 #' both mates of reads if they are repeated. Due to the fact that \code{ScoreMatrix} 
 #' uses the GenomicAlignments:readGAlignmentPairs function to read paired-end BAM files
 #' a duplication of reads occurs when mates of one pair map into two different windows.
+#' 
+#' Strands of reads in a paired-end BAM are inferred depending on strand of 
+#' first alignment from the pair. This is a default setting in the 
+#' GenomicAlignments:readGAlignmentPairs function (see a strandMode argument). 
+#' This mode should be used when the paired-end data was generated using 
+#' one of the following stranded protocols: 
+#' Directional Illumina (Ligation), Standard SOLiD.
 #' 
 #' @return returns a \code{ScoreMatrix} object
 #' @seealso \code{\link{ScoreMatrixBin}}
@@ -246,7 +253,7 @@ setGeneric("ScoreMatrix",
                     extend=0,
                     param=NULL,
                     bam.paired.end=FALSE,
-                    stranded=TRUE) 
+                    library.size=NULL) 
              standardGeneric("ScoreMatrix") )
 
 
@@ -343,12 +350,13 @@ setMethod("ScoreMatrix",signature("GRanges","GRanges"),
 #' @usage \\S4method{ScoreMatrix}{character,GRanges}(target, windows, strand.aware, 
 #'                                                   type='', rpm=FALSE,
 #'                                                   unique=FALSE, extend=0, param=NULL, 
-#'                                                   bam.paired.end=FALSE, stranded=TRUE)
+#'                                                   bam.paired.end=FALSE,
+#'                                                   library.size=NULL)
 setMethod("ScoreMatrix",signature("character","GRanges"),
           function(target,windows, strand.aware, type='', 
                    rpm=FALSE, unique=FALSE, extend=0, 
-                   param=NULL, bam.paired.end=FALSE, 
-                   stranded=TRUE){
+                   param=NULL, bam.paired.end=FALSE,
+                   library.size=NULL){
             
             if(!file.exists(target)){
               stop("Indicated 'target' file does not exist\n")
@@ -356,7 +364,7 @@ setMethod("ScoreMatrix",signature("character","GRanges"),
             
             fm = c('bam','bigWig')
             if(!type %in% fm)
-              stop(paste(c('currently supported formats are', fm)))
+              stop(paste(c('currently supported formats are', paste(fm, collapse=", "))))
             
             if(type == 'bam' & !grepl('bam$',target))
               warning('you have set type="bam", but the designated file does not have .bam extension')
@@ -366,7 +374,7 @@ setMethod("ScoreMatrix",signature("character","GRanges"),
             if(type == 'bam')
               covs = readBam(target, windows, rpm=rpm, unique=unique, 
                              extend=extend, param=param, 
-                             paired.end=bam.paired.end, stranded=stranded)
+                             paired.end=bam.paired.end, library.size)
             if(type == 'bigWig')
               covs = readBigWig(target=target, windows=windows)            
             

--- a/R/scoreMatrixBin.R
+++ b/R/scoreMatrixBin.R
@@ -274,7 +274,7 @@ setMethod("ScoreMatrixBin",signature("character","GRanges"),
               stop("Indicated 'target' file does not exist\n")
             }
             
-            m = c('bam','bigWig')
+            fm = c('bam','bigWig')
             if(!type %in% fm){
 	      if(type==""){
 		stop(paste0('set argument type to "bam" or "BigWig"\n'))

--- a/R/scoreMatrixBin.R
+++ b/R/scoreMatrixBin.R
@@ -274,9 +274,13 @@ setMethod("ScoreMatrixBin",signature("character","GRanges"),
               stop("Indicated 'target' file does not exist\n")
             }
             
-            fm = c('bam','bigWig')
-            if(!type %in% fm)
-              stop(paste(c('currently supported formats are', paste(fm, collapse=", "))))
+            m = c('bam','bigWig')
+            if(!type %in% fm){
+	      if(type==""){
+		stop(paste0('set argument type to "bam" or "BigWig"\n'))
+	      }
+	      stop('currently supported formats are bam and BigWig\n')
+            }
             
             if(type == 'bam' & !grepl('bam$',target))
               warning('you have set type="bam", but the designated file does not have .bam extension')

--- a/R/scoreMatrixBin.R
+++ b/R/scoreMatrixBin.R
@@ -139,18 +139,19 @@ summarizeViewsRle = function(my.vList, windows, bin.op, bin.num, strand.aware){
 #' @param type if target is a character vector of file paths, then type designates 
 #'               the type of the corresponding files (bam or bigWig)
 #' @param rpm boolean telling whether to normalize the coverage to per milion reads. 
-#'            FALSE by default.
+#'            FALSE by default. See \code{library.size}.
 #' @param unique boolean which tells the function to remove duplicated reads 
 #'               based on chr, start, end and strand
 #' @param extend numeric which tells the function to extend the reads to width=extend
 #' @param param ScanBamParam object 
 #' @param bam.paired.end boolean indicating whether given BAM file contains paired-end 
 #'                       reads (default:FALSE). Paired-reads will be treated as 
-#'                       fragments.
-#' @param stranded boolean which tells whether given BAM file is from a strand-specific
-#'                 protocol (default:TRUE). If FALSE then strands of reads will
-#'                 be set up to "*".               
-#'                                                 
+#'                       fragments.             
+#' @param library.size numeric indicating total number of mapped reads in a BAM file
+#'                            (\code{rpm} has to be set to TRUE).
+#'                            If is not given (default: NULL) then library size 
+#'                            is calculated using the Rsamtools package functions:
+#'                            sum(countBam(BamFile(\code{target}))$records).              
 #' @return returns a \code{scoreMatrix} object
 #' 
 #' @examples
@@ -184,7 +185,7 @@ setGeneric("ScoreMatrixBin",
                     extend=0,
                     param=NULL,
                     bam.paired.end=FALSE,
-                    stranded=TRUE
+                    library.size=NULL
                     ) 
              standardGeneric("ScoreMatrixBin") )
 
@@ -262,12 +263,12 @@ setMethod("ScoreMatrixBin",signature("GRanges","GRanges"),
 #'                                                      bin.op='mean',strand.aware, type,
 #'                                                      rpm, unique, extend, param,
 #'                                                      bam.paired.end=FALSE, 
-#'                                                      stranded=TRUE)
+#'                                                      library.size=NULL)
 setMethod("ScoreMatrixBin",signature("character","GRanges"),
           function(target, windows, bin.num=10, 
                    bin.op='mean', strand.aware, 
                    type, rpm, unique, extend, param,
-                   bam.paired.end=FALSE, stranded=TRUE){
+                   bam.paired.end=FALSE, library.size=NULL){
             
             if(!file.exists(target)){
               stop("Indicated 'target' file does not exist\n")
@@ -275,7 +276,7 @@ setMethod("ScoreMatrixBin",signature("character","GRanges"),
             
             fm = c('bam','bigWig')
             if(!type %in% fm)
-              stop(paste(c('currently supported formats are', fm)))
+              stop(paste(c('currently supported formats are', paste(fm, collapse=", "))))
             
             if(type == 'bam' & !grepl('bam$',target))
               warning('you have set type="bam", but the designated file does not have .bam extension')
@@ -285,7 +286,7 @@ setMethod("ScoreMatrixBin",signature("character","GRanges"),
             if(type == 'bam')
               covs = readBam(target, windows, rpm=rpm, unique=unique, 
                              extend=extend, param=param,
-                             paired.end=bam.paired.end, stranded=stranded)
+                             paired.end=bam.paired.end, library.size=library.size)
             if(type == 'bigWig')
               covs = readBigWig(target=target, windows=windows)        
             

--- a/inst/unitTests/test_ScoreMatrix.R
+++ b/inst/unitTests/test_ScoreMatrix.R
@@ -135,6 +135,13 @@ test_ScoreMatrix_character_GRanges = function()
   target.paired.end = target.paired.end[!duplicated(names(target.paired.end))]
   m5 = ScoreMatrix(target.paired.end, windows.paired.end, bam.paired.end=TRUE)
   checkEquals(s5,m5)
+  
+  # test library.size argument
+  s6 = ScoreMatrix(bam.pe.file, windows.paired.end, type='bam', bam.paired.end=TRUE,
+                   rpm=TRUE, library.size=14)
+  s7 = ScoreMatrix(bam.pe.file, windows.paired.end, type='bam', bam.paired.end=TRUE,
+                   rpm=TRUE)
+  checkEquals(s6,s7)
 
   # -----------------------------------------------#
   # errors

--- a/inst/unitTests/test_ScoreMatrixList.R
+++ b/inst/unitTests/test_ScoreMatrixList.R
@@ -162,7 +162,15 @@ test_ScoreMatrixList_Bam = function()
   #bam file, rpm=FALSE, unique=TRUE, extend=1
   s4 = ScoreMatrix(bam.file, windows, type='bam', unique=T, extend=1)
   m4 = ScoreMatrix(resize(unique(target), width=1), windows)
-  checkEquals(s4,m4)        
+  checkEquals(s4,m4)    
+  
+  # bam file, rpm=TRUE, library.size
+  s3 = ScoreMatrixList(bam.files, windows, type='bam', rpm=TRUE)
+  tot= sum(countBam(BamFile(bam.file))$records)
+  s4 = ScoreMatrixList(bam.files, windows, type='bam', rpm=TRUE,
+                       library.size=c(tot,tot))
+  checkEquals(s3, s4)
+        
 }
 
 # ---------------------------------------------------------------------------- #

--- a/man/ScoreMatrix-methods.Rd
+++ b/man/ScoreMatrix-methods.Rd
@@ -10,7 +10,7 @@
 \usage{
 ScoreMatrix(target, windows, strand.aware = FALSE, weight.col = NULL,
   is.noCovNA = FALSE, type = "", rpm = FALSE, unique = FALSE,
-  extend = 0, param = NULL, bam.paired.end = FALSE, stranded = TRUE)
+  extend = 0, param = NULL, bam.paired.end = FALSE, library.size = NULL)
 
 \\S4method{ScoreMatrix}{RleList,GRanges}(target,windows,strand.aware)
 
@@ -20,7 +20,8 @@ ScoreMatrix(target, windows, strand.aware = FALSE, weight.col = NULL,
 \\S4method{ScoreMatrix}{character,GRanges}(target, windows, strand.aware,
                                                   type='', rpm=FALSE,
                                                   unique=FALSE, extend=0, param=NULL,
-                                                  bam.paired.end=FALSE, stranded=TRUE)
+                                                  bam.paired.end=FALSE,
+                                                  library.size=NULL)
 }
 \arguments{
 \item{target}{\code{RleList} , \code{GRanges}, a BAM file or a BigWig
@@ -53,7 +54,7 @@ if TRUE,and if 'target' is a GRanges object with 'weight.col'
 the type of the corresponding files (bam or bigWig)}
 
 \item{rpm}{boolean telling whether to normalize the coverage to per milion
-reads. FALSE by default.}
+reads. FALSE by default. See \code{library.size}.}
 
 \item{unique}{boolean which tells the function to remove duplicated reads
 based on chr, start, end and strand}
@@ -66,9 +67,11 @@ based on chr, start, end and strand}
 paired-end reads (default:FALSE).
 Paired-reads will be treated as fragments.}
 
-\item{stranded}{boolean which tells whether given BAM file is from a strand-specific
-protocol (default:TRUE). If FALSE then strands of reads
-will be set up to "*".}
+\item{library.size}{numeric indicating total number of mapped reads in a BAM file
+                           (\code{rpm} has to be set to TRUE).
+                           If is not given (default: NULL) then library size
+                           is calculated using the Rsamtools package functions:
+                           sum(countBam(BamFile(\code{target}))$records).}
 }
 \value{
 returns a \code{ScoreMatrix} object
@@ -89,6 +92,13 @@ We assume that a paired-end BAM file contains reads with unique ids and we remov
 both mates of reads if they are repeated. Due to the fact that \code{ScoreMatrix}
 uses the GenomicAlignments:readGAlignmentPairs function to read paired-end BAM files
 a duplication of reads occurs when mates of one pair map into two different windows.
+
+Strands of reads in a paired-end BAM are inferred depending on strand of
+first alignment from the pair. This is a default setting in the
+GenomicAlignments:readGAlignmentPairs function (see a strandMode argument).
+This mode should be used when the paired-end data was generated using
+one of the following stranded protocols:
+Directional Illumina (Ligation), Standard SOLiD.
 }
 \examples{
 # When target is GRanges

--- a/man/ScoreMatrixBin-methods.Rd
+++ b/man/ScoreMatrixBin-methods.Rd
@@ -11,7 +11,7 @@
 ScoreMatrixBin(target, windows, bin.num = 10, bin.op = "mean",
   strand.aware = FALSE, weight.col = NULL, is.noCovNA = FALSE,
   type = "", rpm = FALSE, unique = FALSE, extend = 0, param = NULL,
-  bam.paired.end = FALSE, stranded = TRUE)
+  bam.paired.end = FALSE, library.size = NULL)
 
 \\S4method{ScoreMatrixBin}{RleList,GRanges}(target, windows, bin.num, bin.op,
                                                    strand.aware)
@@ -23,7 +23,7 @@ ScoreMatrixBin(target, windows, bin.num = 10, bin.op = "mean",
                                                      bin.op='mean',strand.aware, type,
                                                      rpm, unique, extend, param,
                                                      bam.paired.end=FALSE,
-                                                     stranded=TRUE)
+                                                     library.size=NULL)
 }
 \arguments{
 \item{target}{\code{RleList},  \code{GRanges}, BAM file or a bigWig file
@@ -62,7 +62,7 @@ if TRUE,and if 'target' is a GRanges object with 'weight.col'
 the type of the corresponding files (bam or bigWig)}
 
 \item{rpm}{boolean telling whether to normalize the coverage to per milion reads.
-FALSE by default.}
+FALSE by default. See \code{library.size}.}
 
 \item{unique}{boolean which tells the function to remove duplicated reads
 based on chr, start, end and strand}
@@ -75,9 +75,11 @@ based on chr, start, end and strand}
 reads (default:FALSE). Paired-reads will be treated as
 fragments.}
 
-\item{stranded}{boolean which tells whether given BAM file is from a strand-specific
-                protocol (default:TRUE). If FALSE then strands of reads will
-                be set up to "*".}
+\item{library.size}{numeric indicating total number of mapped reads in a BAM file
+(\code{rpm} has to be set to TRUE).
+If is not given (default: NULL) then library size
+is calculated using the Rsamtools package functions:
+sum(countBam(BamFile(\code{target}))$records).}
 }
 \value{
 returns a \code{scoreMatrix} object

--- a/man/ScoreMatrixList-methods.Rd
+++ b/man/ScoreMatrixList-methods.Rd
@@ -8,7 +8,7 @@
 ScoreMatrixList(targets, windows = NULL, bin.num = NULL, bin.op = "mean",
   strand.aware = FALSE, weight.col = NULL, is.noCovNA = FALSE,
   type = "", rpm = FALSE, unique = FALSE, extend = 0, param = NULL,
-  cores = 1)
+  library.size = NULL, cores = 1)
 }
 \arguments{
 \item{targets}{can be a list of \code{scoreMatrix} objects, that are coerced
@@ -47,7 +47,7 @@ scores, GC content, etc.}
 designates the type of the corresponding files (bam or bigWig)}
 
 \item{rpm}{boolean telling whether to normalize the coverage to per milion reads.
-FALSE by default.}
+FALSE by default. See \code{library.size}.}
 
 \item{unique}{boolean which tells the function to remove duplicated reads
 based on chr, start, end and strand}
@@ -57,6 +57,13 @@ based on chr, start, end and strand}
 length ofwidth+extend}
 
 \item{param}{ScanBamParam object}
+
+\item{library.size}{a numeric vector of the same length as \code{targets}
+indicating total number of mapped reads in BAM files (\code{targets}).
+If is not given (default: NULL) then library sizes for every target
+is calculated using the Rsamtools package functions:
+sum(countBam(BamFile(target))$records).
+\code{rpm} argument has to be set to TRUE.}
 
 \item{cores}{the number of cores to use (default: 1)}
 }


### PR DESCRIPTION
* Update genomation github to be even to 1.3.2 BioC-mirror.

* readGeneric:
    - fixed issue when readTableFast() converted
   numeric columns of metadata to positive integers

* ScoreMatrix, ScoreMatrixBin:
   - changed error msg when type==""