### PR TITLE
RPM is computed based on only mapped reads

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: genomation
 Type: Package
 Title: Summary, annotation and visualization of genomic data
-Version: 1.3.3
+Version: 1.3.4
 Author: Altuna Akalin [aut, cre], Vedran Franke [aut, cre], Katarzyna Wreczycka [aut], Liz Ing-Simmons [ctb]	
 Maintainer: Altuna Akalin <aakalin@gmail.com>, Vedran Franke <vedran.franke@gmail.com>
 Description: A package for summary and annotation of genomic intervals. Users can visualize and 

--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,11 @@
+genomation 1.3.4
+--------------
+
+IMPROVEMENTS AND BUG FIXES
+
+*  RPM is computed based on mapped reads only 
+   (before it was computed on all reads).
+
 genomation 1.3.3
 --------------
 

--- a/R/scoreMatrix.R
+++ b/R/scoreMatrix.R
@@ -111,7 +111,8 @@ readBam = function(target, windows, rpm=FALSE,
   if(rpm){
     message('Normalizing to rpm ...')
     if(is.null(library.size)){
-      total = 1e6/sum(countBam(BamFile(target))$records)
+      param = ScanBamParam( flag = scanBamFlag(isUnmappedQuery=FALSE) )
+      total = 1e6/sum(countBam(BamFile(target), param=param)$records)
     }else{
       total = 1e6/library.size
     }
@@ -200,7 +201,8 @@ readBigWig = function(target, windows=NULL, ...){
 #'                            (\code{rpm} has to be set to TRUE).
 #'                            If is not given (default: NULL) then library size 
 #'                            is calculated using the Rsamtools package functions:
-#'                            sum(countBam(BamFile(\code{target}))$records).
+#'                            param = ScanBamParam(flag = scanBamFlag(isUnmappedQuery=FALSE))
+#'                            sum(countBam(BamFile(\code{target}), param=param)$records).
 #' 
 #' @note
 #' We assume that a paired-end BAM file contains reads with unique ids and we remove 

--- a/R/scoreMatrixBin.R
+++ b/R/scoreMatrixBin.R
@@ -151,7 +151,8 @@ summarizeViewsRle = function(my.vList, windows, bin.op, bin.num, strand.aware){
 #'                            (\code{rpm} has to be set to TRUE).
 #'                            If is not given (default: NULL) then library size 
 #'                            is calculated using the Rsamtools package functions:
-#'                            sum(countBam(BamFile(\code{target}))$records).              
+#'                            param = ScanBamParam(flag = scanBamFlag(isUnmappedQuery=FALSE))
+#'                            sum(countBam(BamFile(\code{target}), param=param)$records).              
 #' @return returns a \code{scoreMatrix} object
 #' 
 #' @examples

--- a/R/scoreMatrixList.R
+++ b/R/scoreMatrixList.R
@@ -69,7 +69,8 @@
 #'                     indicating total number of mapped reads in BAM files (\code{targets}).
 #'                     If is not given (default: NULL) then library sizes for every target
 #'                     is calculated using the Rsamtools package functions:
-#'                     sum(countBam(BamFile(target))$records).
+#'                     param = ScanBamParam( flag = scanBamFlag(isUnmappedQuery=FALSE) )
+#'                     sum(countBam(BamFile(target), param=param)$records).
 #'                     \code{rpm} argument has to be set to TRUE.
 #' @param cores the number of cores to use (default: 1)
 #'

--- a/inst/unitTests/test_ScoreMatrix.R
+++ b/inst/unitTests/test_ScoreMatrix.R
@@ -113,7 +113,8 @@ test_ScoreMatrix_character_GRanges = function()
   
   # bam file, rpm=TRUE
   s2 = ScoreMatrix(bam.file, windows, type='bam', rpm=TRUE)
-  tot = 1e6/countBam(BamFile(bam.file))$records
+  param = ScanBamParam( flag = scanBamFlag(isUnmappedQuery=FALSE) )
+  tot = 1e6/countBam(BamFile(bam.file), param=param)$records
   m2 = m1*tot
   checkEquals(s2, m2)
   

--- a/inst/unitTests/test_ScoreMatrixBin.R
+++ b/inst/unitTests/test_ScoreMatrixBin.R
@@ -115,7 +115,8 @@ test_ScoreMatrixBin_character_GRanges = function()
   
   # bam file, rpm=TRUE
   s2 = ScoreMatrixBin(bam.file, windows,bin.num=2, type='bam', rpm=TRUE)
-  tot = 1e6/countBam(BamFile(bam.file))$records
+  param = ScanBamParam( flag = scanBamFlag(isUnmappedQuery=FALSE) )
+  tot = 1e6/countBam(BamFile(bam.file), param=param)$records
   m2 = m1*tot
   checkEquals(s2, m2)
   

--- a/inst/unitTests/test_ScoreMatrixList.R
+++ b/inst/unitTests/test_ScoreMatrixList.R
@@ -150,7 +150,8 @@ test_ScoreMatrixList_Bam = function()
           
   # bam file, rpm=TRUE
   s2 = ScoreMatrixList(bam.files, windows, type='bam', rpm=TRUE)
-  tot= 1e6/countBam(BamFile(bam.file))$records
+  param = ScanBamParam( flag = scanBamFlag(isUnmappedQuery=FALSE) )
+  tot= 1e6/countBam(BamFile(bam.file), param=param)$records
   m2 = ScoreMatrixList(lapply(sml1, function(x)x*tot))
   checkEquals(s2, m2)
           
@@ -166,7 +167,7 @@ test_ScoreMatrixList_Bam = function()
   
   # bam file, rpm=TRUE, library.size
   s3 = ScoreMatrixList(bam.files, windows, type='bam', rpm=TRUE)
-  tot= sum(countBam(BamFile(bam.file))$records)
+  tot= sum(countBam(BamFile(bam.file), param=param)$records)
   s4 = ScoreMatrixList(bam.files, windows, type='bam', rpm=TRUE,
                        library.size=c(tot,tot))
   checkEquals(s3, s4)

--- a/man/ScoreMatrix-methods.Rd
+++ b/man/ScoreMatrix-methods.Rd
@@ -71,7 +71,8 @@ Paired-reads will be treated as fragments.}
                            (\code{rpm} has to be set to TRUE).
                            If is not given (default: NULL) then library size
                            is calculated using the Rsamtools package functions:
-                           sum(countBam(BamFile(\code{target}))$records).}
+                           param = ScanBamParam(flag = scanBamFlag(isUnmappedQuery=FALSE))
+                           sum(countBam(BamFile(\code{target}), param=param)$records).}
 }
 \value{
 returns a \code{ScoreMatrix} object

--- a/man/ScoreMatrixBin-methods.Rd
+++ b/man/ScoreMatrixBin-methods.Rd
@@ -79,7 +79,8 @@ fragments.}
 (\code{rpm} has to be set to TRUE).
 If is not given (default: NULL) then library size
 is calculated using the Rsamtools package functions:
-sum(countBam(BamFile(\code{target}))$records).}
+param = ScanBamParam(flag = scanBamFlag(isUnmappedQuery=FALSE))
+sum(countBam(BamFile(\code{target}), param=param)$records).}
 }
 \value{
 returns a \code{scoreMatrix} object

--- a/man/ScoreMatrixList-methods.Rd
+++ b/man/ScoreMatrixList-methods.Rd
@@ -62,7 +62,8 @@ length ofwidth+extend}
 indicating total number of mapped reads in BAM files (\code{targets}).
 If is not given (default: NULL) then library sizes for every target
 is calculated using the Rsamtools package functions:
-sum(countBam(BamFile(target))$records).
+param = ScanBamParam( flag = scanBamFlag(isUnmappedQuery=FALSE) )
+sum(countBam(BamFile(target), param=param)$records).
 \code{rpm} argument has to be set to TRUE.}
 
 \item{cores}{the number of cores to use (default: 1)}


### PR DESCRIPTION
* ScoreMatrix:
  - added flag ScanBamParam(flag = scanBamFlag(isUnmappedQuery=FALSE))
    to countBam function