### PR TITLE
Tests for bin.num = 1 and chromosome drops giving wrong SML indices 

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: genomation
 Type: Package
 Title: Summary, annotation and visualization of genomic data
-Version: 1.9.2
+Version: 1.9.3
 Author: Altuna Akalin [aut, cre], Vedran Franke [aut, cre], Katarzyna Wreczycka
     [aut], Alexander Gosdschan [ctb], Liz Ing-Simmons [ctb]
 Maintainer: Altuna Akalin <aakalin@gmail.com>, Vedran Franke

--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,9 @@
+genomation 1.9.3
+--------------
+IMPROVEMENTS AND BUG FIXES
+* tests for different parameter combinations for ScoreMatrixBin
+
+
 genomation 1.9.2
 --------------
 NEW FUNCTIONS AND FEATURES

--- a/inst/unitTests/test_ScoreMatrix.R
+++ b/inst/unitTests/test_ScoreMatrix.R
@@ -205,13 +205,13 @@ test_ScoreMatrix_Ops = function()
 	
 # ---------------------------------------------------------------------------- #
 # test for constrainRanges
-test_constrainRanges = function()
-{
-	target = RleList(chr1 = Rle(rep(c(1,2,3), each=3)), chr2=Rle(rep(c(4,5,6), each=3)))
-	gr1 = GRanges(rep(c('chr1','chr2'), each=2), IRanges(c(1,5,1,8),c(3,7,3,10)))
-	gt1 = GRanges(c('chr1','chr1','chr2'), IRanges(c(1,5,1),c(3,7,3)))
-	expect_identical(genomation:::constrainRanges(target, gr1), gt1)
-}
+# test_constrainRanges = function()
+# {
+# 	target = RleList(chr1 = Rle(rep(c(1,2,3), each=3)), chr2=Rle(rep(c(4,5,6), each=3)))
+# 	gr1 = GRanges(rep(c('chr1','chr2'), each=2), IRanges(c(1,5,1,8),c(3,7,3,10)))
+# 	gt1 = GRanges(c('chr1','chr1','chr2'), IRanges(c(1,5,1),c(3,7,3)))
+# 	expect_identical(genomation:::constrainRanges(target, gr1), gt1)
+# }
 
 
 # ---------------------------------------------------------------------------- #

--- a/inst/unitTests/test_ScoreMatrix.R
+++ b/inst/unitTests/test_ScoreMatrix.R
@@ -205,14 +205,14 @@ test_ScoreMatrix_Ops = function()
 	
 # ---------------------------------------------------------------------------- #
 # test for constrainRanges
-# test_that("constrainRanges works",
-# 	{
-# 		target = RleList(chr1 = Rle(rep(c(1,2,3), each=3)), chr2=Rle(rep(c(4,5,6), each=3)))
-# 		gr1 = GRanges(rep(c('chr1','chr2'), each=2), IRanges(c(1,5,1,8),c(3,7,3,10)))
-# 		gt1 = GRanges(c('chr1','chr1','chr2'), IRanges(c(1,5,1),c(3,7,3)))
-# 		expect_identical(constrainRanges(target, gr1), gt1)
-# 	}
-# )
+test_constrainRanges = function()
+{
+	target = RleList(chr1 = Rle(rep(c(1,2,3), each=3)), chr2=Rle(rep(c(4,5,6), each=3)))
+	gr1 = GRanges(rep(c('chr1','chr2'), each=2), IRanges(c(1,5,1,8),c(3,7,3,10)))
+	gt1 = GRanges(c('chr1','chr1','chr2'), IRanges(c(1,5,1),c(3,7,3)))
+	expect_identical(genomation:::constrainRanges(target, gr1), gt1)
+}
+
 
 # ---------------------------------------------------------------------------- #
 # test for binMatrix

--- a/inst/unitTests/test_ScoreMatrixBin.R
+++ b/inst/unitTests/test_ScoreMatrixBin.R
@@ -41,6 +41,21 @@ test_ScoreMatrixBin_RleList_GRanges = function()
   s3 = ScoreMatrixBin(rl, gr1, bin.num=2, strand.aware=T)
   checkEquals(s3, m3)
   
+  #4.A bin.num > 1 and dropping chromosomes
+  t4 = GRanges(rep(c('chr1','chr2'), times=c(3,2)), IRanges(c(seq(1,20,4)), width=3))
+  t4$score = 1
+  w4 = GRanges(rep(c('chr3','chr2'), each=2), IRanges(rep(c(13,17), times=2), width=3))
+  s4 = suppressWarnings(ScoreMatrixBin(t4, w4,bin.num = 2,type = "bigWig"))
+  checkEquals(as.numeric(rownames(as.data.frame(s4))), c(3,4))
+  
+  
+  #4.A bin.num = 1 and dropping chromosomes
+  t4 = GRanges(rep(c('chr1','chr2'), times=c(3,2)), IRanges(c(seq(1,20,4)), width=3))
+  t4$score = 1
+  w4 = GRanges(rep(c('chr3','chr2'), each=2), IRanges(rep(c(13,17), times=2), width=3))
+  s4 = suppressWarnings(ScoreMatrixBin(t4, w4,bin.num = 1,type = "bigWig"))
+  checkEquals(as.numeric(rownames(as.data.frame(s4))), c(3,4))
+  
   # -----------------------------------------------#
   # errors
   # error for removing all bins

--- a/inst/unitTests/test_ScoreMatrixBin.R
+++ b/inst/unitTests/test_ScoreMatrixBin.R
@@ -45,16 +45,15 @@ test_ScoreMatrixBin_RleList_GRanges = function()
   t4 = GRanges(rep(c('chr1','chr2'), times=c(3,2)), IRanges(c(seq(1,20,4)), width=3))
   t4$score = 1
   w4 = GRanges(rep(c('chr3','chr2'), each=2), IRanges(rep(c(13,17), times=2), width=3))
-  s4 = suppressWarnings(ScoreMatrixBin(t4, w4,bin.num = 2,type = "bigWig"))
+  s4 = suppressWarnings(ScoreMatrixBin(t4, w4, bin.num = 2,type = "bigWig"))
   checkEquals(as.numeric(rownames(as.data.frame(s4))), c(3,4))
   
-  
-  #4.A bin.num = 1 and dropping chromosomes
-  t4 = GRanges(rep(c('chr1','chr2'), times=c(3,2)), IRanges(c(seq(1,20,4)), width=3))
-  t4$score = 1
-  w4 = GRanges(rep(c('chr3','chr2'), each=2), IRanges(rep(c(13,17), times=2), width=3))
-  s4 = suppressWarnings(ScoreMatrixBin(t4, w4,bin.num = 1,type = "bigWig"))
-  checkEquals(as.numeric(rownames(as.data.frame(s4))), c(3,4))
+  #4.B bin.num = 1 and dropping chromosomes
+  t5 = GRanges(rep(c('chr1','chr2'), times=c(3,2)), IRanges(c(seq(1,20,4)), width=3))
+  t5$score = 1
+  w5 = GRanges(rep(c('chr3','chr2'), each=2), IRanges(rep(c(13,17), times=2), width=3))
+  s5 = suppressWarnings(ScoreMatrixBin(t5, w5,bin.num = 1,type = "bigWig"))
+  checkEquals(as.numeric(rownames(as.data.frame(s5))), c(3,4))
   
   # -----------------------------------------------#
   # errors


### PR DESCRIPTION
Create tests for previously reported bugs, however, the new version of genomation passes the tests, so no code refactoring was necessary.
I think it's nice to add the tests for this specific case, though

closes issue:
#157