### PR TITLE
Update README to use BiocManager

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,7 @@ language: r
 
 # See https://docs.travis-ci.com/user/languages/r/#R-Versions
 r:
-    - release
-    - devel
+    - bioc-devel
      
 
 sudo: required

--- a/README.md
+++ b/README.md
@@ -17,8 +17,9 @@ with other genomic features such as exons,introns and promoters.
 
 ### install via Bioconductor
 ```R
-source("http://bioconductor.org/biocLite.R")
-biocLite("genomation")
+if (!"BiocManager" %in% rownames(installed.packages()))
+  install.packages("BiocManager")
+BiocManager::install("genomation")
 
 ```
 
@@ -26,8 +27,10 @@ biocLite("genomation")
 ```R
 #' Install dependecies
 install.packages( c("data.table","plyr","reshape2","ggplot2","gridBase","devtools"))
-source("http://bioconductor.org/biocLite.R")
-biocLite(c("GenomicRanges","rtracklayer","impute","Rsamtools"))
+if (!"BiocManager" %in% rownames(installed.packages()))
+  install.packages("BiocManager")
+BiocManager::install(c("GenomicRanges","rtracklayer","impute","Rsamtools"))
+
 
 #' install the packages
 library(devtools)

--- a/README.md
+++ b/README.md
@@ -25,16 +25,14 @@ BiocManager::install("genomation")
 
 ### Install the latest version via install_github
 ```R
-#' Install dependecies
-install.packages( c("data.table","plyr","reshape2","ggplot2","gridBase","devtools"))
 if (!"BiocManager" %in% rownames(installed.packages()))
   install.packages("BiocManager")
-BiocManager::install(c("GenomicRanges","rtracklayer","impute","Rsamtools"))
+if (!"devtools" %in% rownames(installed.packages()))
+  install.packages("devtools")
 
-
-#' install the packages
 library(devtools)
-install_github("BIMSBbioinfo/genomation",build_vignettes=FALSE)
+install_github("BIMSBbioinfo/genomation",build_vignettes=FALSE,
+               repos=BiocManager::repositories(), dependencies=TRUE)
 
 ```
 


### PR DESCRIPTION
According to Bioc-devel mailing list the BiocManager package (https://cran.r-project.org/web/packages/BiocManager/vignettes/BiocManager.html) is now a way to go to install and manage packages from the Bioconductor project and soon will be replaced from biocLite.